### PR TITLE
Port to ES6 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-sax-token-stream
 
-A Node.js [Transform stream][1] that pipes tokens from a SAX style parser.
+An ES6 Node.js [Transform stream][1] that pipes tokens from a SAX style parser.
 
 A widespread pattern with streaming parsers is to emit events when tokens are parsed from an
 input string. Examples include [SAX][2] libraries, [parse5][3] (HTML), and other streaming 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "0.1.0",
   "description": "A Node.js Transform stream that pipes tokens from a SAX style parser",
   "main": "src/index.js",
+  "type": "module",
   "types": "src/index.d.ts",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "docs": "jsdoc -c jsdoc.conf.json -r src -d docs -R README.md",
     "test": "mocha test"

--- a/src/adaptors/sax-event-adaptor.js
+++ b/src/adaptors/sax-event-adaptor.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const EventEmitter = require("node:events");
+import EventEmitter from "node:events";
 
-const { TokenisingStream } = require("tokenising-stream");
+import { TokenisingStream } from "tokenising-stream";
 
-const { assign2 } = require("./utils");
+import { assign2 } from "./utils.js";
 
 /**
  * @typedef {Object} SAXEventAdaptor~AttributeToken
@@ -129,7 +129,7 @@ const { assign2 } = require("./utils");
  * @implements EventAdaptor
  * @see https://www.npmjs.com/package/sax
  */
-class SAXEventAdaptor extends EventEmitter {
+export default class SAXEventAdaptor extends EventEmitter {
 	/**
 	 * @param {EventEmitter} delegate
 	 */
@@ -238,5 +238,3 @@ class SAXEventAdaptor extends EventEmitter {
 		})
 	}
 }
-
-module.exports = SAXEventAdaptor;

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -1,7 +1,3 @@
 "use strict";
 
-const assign2 = (a, b) => Object.assign({}, a, b);
-
-module.exports = {
-	assign2
-}
+export const assign2 = (a, b) => Object.assign({}, a, b);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const { TokenisingStream } = require("tokenising-stream");
+import { TokenisingStream } from "tokenising-stream";
 
-const SAXEventAdaptor = require("./adaptors/sax-event-adaptor");
+import SAXEventAdaptor from "./adaptors/sax-event-adaptor.js";
 
 /**
  * See the {@link SAXEventAdaptor} documentation for token details.
@@ -10,12 +10,8 @@ const SAXEventAdaptor = require("./adaptors/sax-event-adaptor");
  * @param {Writable} parser
  * @returns TokenisingStream
  */
-const newSAXStream = (parser) =>
+export const newSAXStream = (parser) =>
 	new TokenisingStream({
 		delegate: parser,
 		adaptor: new SAXEventAdaptor(parser)
 	})
-
-module.exports = {
-	newSAXStream
-}

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,16 @@
 "use strict";
 
-const fs = require("node:fs");
-const path = require("node:path");
-const { Writable } = require("stream");
-const { pipeline } = require("node:stream/promises");
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import { Writable } from "stream";
+import { pipeline } from "node:stream/promises";
 
-const { allOf, assertThat, hasItem, hasProperties } = require("hamjest");
+import { allOf, assertThat, hasItem, hasProperties } from "hamjest";
 
-const sax = require("sax");
+import sax from "sax";
 
-const { newSAXStream } = require("../src");
+import { newSAXStream } from "../src/index.js";
 
 describe("streams", function() {
 	describe("newSAXStream", function() {
@@ -136,7 +137,10 @@ class CollectorStream extends Writable {
 
 // readFileStream :: String -> ReadStream
 const readFileStream = (file) =>
-	fs.createReadStream(path.join(__dirname, file), { encoding: "utf8" });
+	fs.createReadStream(
+		path.join(path.dirname(url.fileURLToPath(import.meta.url)), file),
+		{ encoding: "utf8" }
+	);
 
 const parse = async (parser, input) => {
 	const collector = new CollectorStream()


### PR DESCRIPTION
parse5 requires ESM.